### PR TITLE
Pagination cursor feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
+## [v0.1.1](https://github.com/mmarusyk/easyship/tree/v0.1.1) - 2024-06-08
 
-## [0.1.0] - 2024-06-08
+### Features
+- Add pagination cursor by @mmarusyk in https://github.com/mmarusyk/easyship/pull/1
+
+## [v0.1.0](https://github.com/mmarusyk/easyship/tree/v0.1.0) - 2024-06-08
 
 - Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    easyship (0.1.0)
+    easyship (0.1.1)
       faraday (~> 2.9)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This gem provides a simple client for Easyship, offering accessing to Easyship's
 
 Install the gem and add to the application's Gemfile by executing:
 
-    $ bundle add easyhip
+    $ bundle add easyship
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
@@ -46,7 +46,7 @@ Easyship::Configuration.configure do |config|
   config.api_key = 'your_easyship_api_key'
 end
 ```
-
+Configuration supports the next keys: `url`, `api_key`, `per_page`.
 
 ### Making Requests
 ```ruby
@@ -79,7 +79,7 @@ Easyship::Client.post('/2023-01/shipment', payload)
 ```
 
 ### Handle errors
-hen using the `easyship` gem in a Rails application, it's important to handle potential errors that may arise during API calls. Here's how you can handle errors gracefully:
+Then using the `easyship` gem in a Rails application, it's important to handle potential errors that may arise during API calls. Here's how you can handle errors gracefully:
 
 1. Wrap your API calls in a `begin-rescue` block.
 2. Catch specific errors from the `easyship` gem to handle them accordingly.
@@ -94,11 +94,29 @@ rescue Easyship::Errors::RateLimitError => e
 end
 ```
 
+### Pagination
+The `get` method in the `Easyship::Client` class is designed to support pagination seamlessly when interacting with the Easyship API by passing block of code. This method abstracts the complexity of managing pagination logic, allowing you to retrieve all items across multiple pages with a single method call.
+
+Suppose you want to retrieve a list of shipments that may span multiple pages. Here's how you can use the `get` method:
+
+```ruby
+shipments = []
+
+Easyship::Client.instance.get('/2023-01/shipments') do |page|
+  shipments.concat(page[:shipments])
+end
+
+shipments # Returns all shipments from all pages
+```
+
+To setup items perpage, use the key `per_page` in your configuration.
+
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. Then, eun `rake rubocop` to run the rubocop. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
 
 ## Contributing
 

--- a/lib/easyship/client.rb
+++ b/lib/easyship/client.rb
@@ -4,6 +4,7 @@ require 'singleton'
 require 'faraday'
 require_relative 'middleware/error_handler_middleware'
 require_relative 'handlers/response_body_handler'
+require_relative 'pagination/cursor'
 
 module Easyship
   # Represents a client to interact with the Easyship API
@@ -15,10 +16,14 @@ module Easyship
       @api_key = Easyship.configuration.api_key
     end
 
-    def get(path, params = {})
-      response = connection.get(path, params)
+    def get(path, params = {}, &block)
+      if block
+        Easyship::Pagination::Cursor.new(self, path, params).all(&block)
+      else
+        response = connection.get(path, params)
 
-      handle_response(response)
+        handle_response(response)
+      end
     end
 
     def post(path, params = {})

--- a/lib/easyship/configuration.rb
+++ b/lib/easyship/configuration.rb
@@ -3,11 +3,12 @@
 module Easyship
   # Represents the configuration settings for the Easyship client.
   class Configuration
-    attr_accessor :url, :api_key
+    attr_accessor :url, :api_key, :per_page
 
     def initialize
       @url = nil
       @api_key = nil
+      @per_page = 100 # Maximum possible number of items per page
     end
   end
 end

--- a/lib/easyship/handlers/response_body_handler.rb
+++ b/lib/easyship/handlers/response_body_handler.rb
@@ -5,9 +5,9 @@ module Easyship
     # Handles the response body
     class ResponseBodyHandler
       def self.handle_response(response)
-        JSON.parse(response.body, symbolize_names: true)
-      rescue JSON::ParserError
-        response.body
+        body = response.body
+
+        JSON.parse(body, symbolize_names: true) unless body.nil? || body.empty?
       end
     end
   end

--- a/lib/easyship/pagination/cursor.rb
+++ b/lib/easyship/pagination/cursor.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Easyship
+  module Pagination
+    # Represents a pagination object
+    class Cursor
+      attr_reader :client, :path, :params, :key, :per_page
+
+      def initialize(client, path, params)
+        @client = client
+        @path = path
+        @params = params
+        @per_page = params[:per_page] || Easyship.configuration.per_page
+      end
+
+      def all
+        page = 1
+
+        loop do
+          body = client.get(path, params.merge(page: page, per_page: per_page))
+
+          break if body.nil? || body.empty?
+
+          yield body
+
+          break if body.dig(:meta, :pagination, :next).nil?
+
+          page += 1
+        end
+      end
+    end
+  end
+end

--- a/lib/easyship/version.rb
+++ b/lib/easyship/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Easyship
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
This PR adds pagination cursor feature.

The `get` method in the `Easyship::Client` class is designed to support pagination seamlessly when interacting with the Easyship API by passing block of code. This method abstracts the complexity of managing pagination logic, allowing you to retrieve all items across multiple pages with a single method call.

Suppose you want to retrieve a list of shipments that may span multiple pages. Here's how you can use the `get` method:

```ruby
shipments = []

Easyship::Client.instance.get('/2023-01/shipments') do |page|
  shipments.concat(page[:shipments])
end

shipments # Returns all shipments from all pages
```

To setup items perpage, use the key `per_page` in your configuration.