### PR TITLE
Deprecate body_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ end
 Each error instance provides these methods:
 
 - `message`: Returns the error message text.
-- `body_error`: Returns a hash containing detailed error information.
+- `body_error`: Returns an error details **(Deprecated)**.
+- `error`: Returns a hash containing original detailed error object from Easyship.
 - `response_body`: Returns the full response body from the API.
 - `response_headers`: Returns the HTTP headers from the API response.
 

--- a/lib/easyship/errors/easyship_error.rb
+++ b/lib/easyship/errors/easyship_error.rb
@@ -4,14 +4,20 @@ module Easyship
   module Errors
     # Represents an error that is raised when an error occurs in the Easyship API.
     class EasyshipError < StandardError
-      attr_reader :message, :body_error, :response_body, :response_headers
+      attr_reader :message, :error, :response_body, :response_headers
 
-      def initialize(message: '', body_error: {}, response_body: nil, response_headers: {})
+      def initialize(message: '', body_error: {}, error: {}, response_body: nil, response_headers: {})
         super(message)
+        @error = error
         @message = message
         @body_error = body_error
         @response_body = response_body
         @response_headers = response_headers
+      end
+
+      def body_error
+        warn '[DEPRECATION] `body_error` is deprecated. Please use `error` instead.'
+        @body_error
       end
     end
   end

--- a/lib/easyship/middleware/error_handler_middleware.rb
+++ b/lib/easyship/middleware/error_handler_middleware.rb
@@ -26,9 +26,16 @@ module Easyship
         raise class_error.new(
           message: message(body),
           body_error: body_error(body),
+          error: build_error(body),
           response_body: body,
           response_headers: headers
         )
+      end
+
+      def build_error(body)
+        return default_error unless body.is_a?(Hash)
+
+        body[:error]
       end
 
       def body_error(body)
@@ -59,6 +66,10 @@ module Easyship
 
       def format_by_default(body)
         { details: body, message: 'Something went wrong.' }
+      end
+
+      def default_error
+        { details: [], message: 'Something went wrong.' }
       end
 
       def response_body(body)

--- a/spec/lib/easyship/errors/easyship_error_spec.rb
+++ b/spec/lib/easyship/errors/easyship_error_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Easyship::Errors::EasyshipError do
+  subject(:easyship_error) { described_class.new(body_error: body_error) }
+
+  let(:body_error) { { details: [], message: 'Something went wrong' } }
+
+  describe '#body_error' do
+    it 'outputs a deprecation warning' do
+      expect { easyship_error.body_error }.to output(/\[DEPRECATION\] `body_error` is deprecated/).to_stderr
+    end
+
+    it 'returns the body_error value' do
+      expect(easyship_error.body_error).to eq(body_error)
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this gem!

Please fill out the sections below to help maintainers understand your changes.
-->

## 📋 Description

This PR introduces a deprecation warning for the `body_error` attribute in EasyshipError and promotes the use of the new `error` attribute. This change aims to simplify error handling and reduce parsing issues when working with different versions of the Easyship API.

The `body_error` attribute was originally implemented to unify error responses from different Easyship API versions, which sometimes presented errors in different formats. While this provided a consistent interface, it introduced additional complexity in parsing and normalizing these error responses.

As the Easyship API has become more standardized, we can now simplify our error handling by directly exposing the original error object from the API. This reduces potential parsing issues and provides more direct access to the API's error information.

In case Easyship returns not `error` object, will be displayed default error:
```ruby
{ details: [], message: 'Something went wrong.' }
```

In this PR:

- Added error attribute to EasyshipError class
- Added deprecation warning when `body_error` is accessed
- Update README.md

When encountering errors, users should transition from:

```ruby
rescue Easyship::Errors::SomeError => e
  e.body_error # Will now show deprecation warning
end
```

To using:

```ruby
rescue Easyship::Errors::SomeError => e
  e.error # Provides direct access to the original API error
end
```


## ✅ Related Issues / Tickets

## 🧪 Type of Change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Refactor 🔧
- [ ] Documentation update 📝
- [ ] Other (please describe):

## 🛠️ Checklist

Please make sure your PR meets the following requirements:

- [ ] I've added or updated tests where necessary.
- [ ] I've updated documentation if needed.
- [ ] I've run the test suite and verified that all tests pass.
- [ ] My code follows the style guide of this project.

## 📸 Screenshots / Demo (if applicable)

## 🧠 Additional Context
