### PR TITLE
Add rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 .rspec_status
 
 .env
+
+# IDE files
+.idea/

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Easyship.configure do |config|
 end
 ```
 
-Configuration supports the next keys: `url`, `api_key`, `per_page`.
+Configuration supports the next keys: `url`, `api_key`, `per_page`, `requests_per_second`, `requests_per_minute`.
 
 ### Making Requests
 `Easyship::Client` supports the next methods: `get`, `post`, `put`, `delete`.
@@ -131,7 +131,48 @@ end
 shipments # Returns all shipments from all pages
 ```
 
-To setup items perpage, use the key `per_page` in your configuration.
+To setup items per page, use the key `per_page` in your configuration.
+
+For Example:
+
+```ruby
+# Global defaults
+Easyship.configure do |config|
+  config.per_page = 100
+end
+
+# Per-call overrides (any of these are supported)
+shipments = []
+Easyship::Client.instance.get('/2023-01/shipments', {
+  per_page: 50,
+}) do |page|
+  shipments.concat(page[:shipments])
+end
+```
+
+Rate limiting during pagination:
+- The cursor has no default rate limiting; it uses nil to indicate that rate limiting is disabled.
+  - Use [Rate limiting documentation](https://developers.easyship.com/reference/rate-limit) for more details which values to set.
+- You can override the limits per call, by passing `requests_per_second` and `requests_per_minute`.
+
+Examples:
+
+```ruby
+# Global defaults
+Easyship.configure do |config|
+  config.requests_per_second = 10
+  config.requests_per_minute = 60
+end
+
+# Per-call overrides (any of these are supported)
+shipments = []
+Easyship::Client.instance.get('/2023-01/shipments', {
+  requests_per_second: 5,
+  requests_per_minute: 40,
+}) do |page|
+  shipments.concat(page[:shipments])
+end
+```
 
 ## Development
 

--- a/lib/easyship.rb
+++ b/lib/easyship.rb
@@ -3,6 +3,8 @@
 require_relative 'easyship/version'
 require_relative 'easyship/configuration'
 require_relative 'easyship/client'
+require_relative 'easyship/rate_limiting/rate_limiter'
+require_relative 'easyship/rate_limiting/window_rate_limiter'
 
 # Provides configuration options for the Easyship gem.
 module Easyship

--- a/lib/easyship/configuration.rb
+++ b/lib/easyship/configuration.rb
@@ -3,12 +3,14 @@
 module Easyship
   # Represents the configuration settings for the Easyship client.
   class Configuration
-    attr_accessor :url, :api_key, :per_page
+    attr_accessor :url, :api_key, :per_page, :requests_per_second, :requests_per_minute
 
     def initialize
       @url = nil
       @api_key = nil
       @per_page = 100 # Maximum possible number of items per page
+      @requests_per_second = nil
+      @requests_per_minute = nil
     end
   end
 end

--- a/lib/easyship/rate_limiting/rate_limiter.rb
+++ b/lib/easyship/rate_limiting/rate_limiter.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Easyship
+  module RateLimiting
+    # Represents RateLimiter
+    class RateLimiter
+      def throttle!
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/easyship/rate_limiting/window_rate_limiter.rb
+++ b/lib/easyship/rate_limiting/window_rate_limiter.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Easyship
+  module RateLimiting
+    # Represents WindowRateLimiter
+    class WindowRateLimiter < RateLimiter
+      attr_reader :timestamps, :requests_per_second, :requests_per_minute
+
+      def initialize(requests_per_second:, requests_per_minute:)
+        super()
+        @requests_per_second = requests_per_second
+        @requests_per_minute = requests_per_minute
+        @timestamps = []
+      end
+
+      def throttle!
+        now = Time.now
+
+        timestamps << now
+
+        # Remove timestamps older than a minute
+        timestamps.reject! { |t| t < now - 60 }
+
+        check_second_window(now)
+        check_minute_window(now)
+      end
+
+      private
+
+      def check_second_window(now)
+        second_requests = timestamps.count { |t| t > now - 1 }
+
+        return if !requests_per_second || second_requests < requests_per_second
+
+        first_in_seconds = timestamps.find { |t| t > now - 1 }
+        sleep_time = (first_in_seconds + 1) - now
+
+        sleep(sleep_time) if sleep_time.positive?
+      end
+
+      def check_minute_window(now)
+        return if !requests_per_minute || timestamps.size < requests_per_minute
+
+        sleep_time = (timestamps.first + 60) - now
+
+        sleep(sleep_time) if sleep_time.positive?
+      end
+    end
+  end
+end

--- a/spec/cassettes/rate_limit_error.yml
+++ b/spec/cassettes/rate_limit_error.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.easyship.com/2024-09/countries
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <API_KEY>
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v2.9.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 429
+      message: Too Many Requests
+    headers:
+      Date:
+      - Fri, 28 Nov 2025 18:55:59 GMT
+      Content-Length:
+      - '353'
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '1'
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Reset:
+      - '1764356160'
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - 'default-src ''none''; font-src ''self'' https: data:; img-src ''self'' https:
+        data:; object-src ''none''; script-src ''self'' https: ''nonce-''; style-src
+        ''self'' https: ''nonce-''; frame-ancestors https://*.easyship.com'
+      X-Request-Id:
+      - 384042d3615f3adc2beeaace672a6899
+      X-Runtime:
+      - '0.046550'
+      Vary:
+      - Origin
+      X-Rack-Cors:
+      - miss; no-origin
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9a5c152d89829a49-BCN
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"too_many_requests","details":["You have reached the
+        maximum number of requests per second. Contact your account manager to request
+        a higher limit."],"message":"Rate Limit Exceeded. You have reached the maximum
+        number of requests. Please try again later.","request_id":"384042d3615f3adc2beeaace672a6899","type":"invalid_request_error"}}'
+  recorded_at: Fri, 28 Nov 2025 18:56:00 GMT
+recorded_with: VCR 6.2.0

--- a/spec/lib/easyship/pagination/cursor_spec.rb
+++ b/spec/lib/easyship/pagination/cursor_spec.rb
@@ -33,5 +33,24 @@ RSpec.describe Easyship::Pagination::Cursor do
         end
       end
     end
+
+    context 'when request throttling present' do
+      let(:expected_pages) { 3 }
+
+      let(:params) do
+        {
+          requests_per_second: 1,
+          requests_per_minute: 5
+        }
+      end
+
+      it 'yields each page of results' do
+        VCR.use_cassette('countries') do
+          cursor.all { |p| results << p }
+
+          expect(results.count).to eq(expected_pages)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/easyship/rate_limiting/window_rate_limiter_spec.rb
+++ b/spec/lib/easyship/rate_limiting/window_rate_limiter_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Easyship::RateLimiting::WindowRateLimiter do
+  describe '#throttle!' do
+    context 'when under all limits' do
+      it 'does not sleep' do
+        limiter = described_class.new(requests_per_second: 10, requests_per_minute: 60)
+        base = Time.at(0)
+        allow(Time).to receive(:now).and_return(base, base + 0.05, base + 0.10)
+        allow(limiter).to receive(:sleep)
+
+        3.times { limiter.throttle! }
+
+        expect(limiter).not_to have_received(:sleep)
+      end
+    end
+
+    context 'when exceeding the per-second limit' do
+      it 'sleeps until the next second window' do
+        limiter = described_class.new(requests_per_second: 2, requests_per_minute: nil)
+        t0 = Time.at(0.0)
+        t1 = Time.at(0.4)
+        t2 = Time.at(0.8)
+
+        allow(Time).to receive(:now).and_return(t0, t1, t2)
+        allow(limiter).to receive(:sleep)
+
+        3.times { limiter.throttle! }
+
+        expect(limiter).to have_received(:sleep).at_least(:once).with(satisfy { |x| x.is_a?(Numeric) && x > 0 })
+      end
+    end
+
+    context 'when exceeding the per-minute limit' do
+      it 'sleeps until the next minute window' do
+        limiter = described_class.new(requests_per_second: nil, requests_per_minute: 2)
+        t0 = Time.at(0)
+        t1 = Time.at(10)
+        t2 = Time.at(20)
+
+        allow(Time).to receive(:now).and_return(t0, t1, t2)
+        allow(limiter).to receive(:sleep)
+
+        3.times { limiter.throttle! }
+
+        expect(limiter).to have_received(:sleep).at_least(:once).with(satisfy { |x| x.is_a?(Numeric) && x > 0 })
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this gem!

Please fill out the sections below to help maintainers understand your changes.
-->

## 📋 Description

This pull request adds support for configurable API rate limiting to the Easyship gem, allowing users to control the number of requests per second and per minute both globally and per API call. It introduces a new rate limiting system, updates the pagination logic to respect these limits, and provides thorough documentation and tests for these features.

## ✅ Related Issues / Tickets

## 🧪 Type of Change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Refactor 🔧
- [ ] Documentation update 📝
- [ ] Other (please describe):

## 🛠️ Checklist

Please make sure your PR meets the following requirements:

- [x] I've added or updated tests where necessary.
- [x] I've updated documentation if needed.
- [x] I've run the test suite and verified that all tests pass.
- [x] My code follows the style guide of this project.

## 📸 Screenshots / Demo (if applicable)

## 🧠 Additional Context
